### PR TITLE
Update build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -58,7 +58,7 @@ build_catalyst_libs()
 build_sim_libs()
 {
 	if [[ ! -d $BUILD_DIR/build/lib.iossim-$1 ]]; then
-		./Configure --openssldir="$BUILD_DIR/build/ssl" no-shared iossimulator-xcrun CFLAGS="-arch $1"
+		./Configure --openssldir="$BUILD_DIR/build/ssl" no-shared iossimulator-xcrun CFLAGS="-arch $1 -mios-simulator-version-min=13.4"
 		make clean
 		make -j$THREAD_COUNT
 


### PR DESCRIPTION
Explicit minimum deployment target for ios simulator to avoid multiple warnings of type ".../Build/Products/Debug-iphonesimulator/XCFrameworkIntermediates/openssl-iosx/libssl.a(bio_ssl.o)) was built for newer iOS Simulator version (16.4) than being linked (14.2)"