### PR TITLE
Add info about cmake dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The actual library version is taken from https://github.com/openssl/openssl with
    /Applications/Xcode.app/Contents/Developer/Platforms
 ```
 
+4. Install cmake. Requires cmake 3.x (will not work with cmake 4.0 or higher). Compatible versions can be downloaded from [cmake.org](https://cmake.org/download/#older)
+
 # Build Manually
 ```
     # clone the repo

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -91,7 +91,7 @@ BUILD_PLATFORMS=" ${BUILD_PLATFORMS//,/ } "
 for i in $BUILD_PLATFORMS; do :;
 if [[ ! ",$BUILD_PLATFORMS_ALL," == *",$i,"* ]]; then
     echo "Unknown platform '$i'"
-    exi1 1
+    exit 1
 fi
 done
 


### PR DESCRIPTION
Hi @apotocki 

Thanks for this very useful repository.  I struggled to build it today and discovered that my cmake installed via homebrew was too new.  My understanding is that there are many breaking changes between v 3.x and 4.x of cmake.  After I installed an older cmake `3.31.10` everything worked perfectly.

There was also a typo in the build script that you would only catch if you tried to specify the build platform.